### PR TITLE
Filter empty meshcoreKeys when closing config popover

### DIFF
--- a/src/components/ConfigContext.tsx
+++ b/src/components/ConfigContext.tsx
@@ -90,7 +90,13 @@ export function ConfigProvider({ children }: { children: ReactNode }) {
         <MeshcoreKeyModal
           config={config}
           setConfig={setConfig}
-          onClose={() => setKeyModalOpen(false)}
+          onClose={() => {
+            setConfig({
+              ...config,
+              meshcoreKeys: [...(config.meshcoreKeys?.filter(({channelName, privateKey}) => channelName !== "" || privateKey !== "") || [])],
+            });
+            setKeyModalOpen(false)
+          }}
         />
       )}
     </ConfigContext.Provider>


### PR DESCRIPTION
When closing the ConfigPopover, filter out meshcoreKeys with empty channelName and privateKey. This prevents keeping an empty entry which generates warnings and adds a 00 to the tab bar when a user hits the add button too many times and just closes the popover.