### PR TITLE
Support Lowercase Public Keys in Node API Endpoints

### DIFF
--- a/src/app/api/meshcore/node/[publicKey]/neighbors/route.ts
+++ b/src/app/api/meshcore/node/[publicKey]/neighbors/route.ts
@@ -6,11 +6,11 @@ export async function GET(
   { params }: { params: Promise<{ publicKey: string }> }
 ) {
   try {
-    const { publicKey } = await params;
+    const { publicKey: rawPublicKey } = await params;
     const { searchParams } = new URL(req.url);
     const lastSeen = searchParams.get("lastSeen");
     
-    if (!publicKey) {
+    if (!rawPublicKey) {
       return NextResponse.json({ 
         error: "Public key is required",
         code: "MISSING_PUBLIC_KEY"
@@ -18,12 +18,15 @@ export async function GET(
     }
 
     // Validate public key format (basic validation)
-    if (publicKey.length < 10) {
+    if (rawPublicKey.length < 10) {
       return NextResponse.json({ 
         error: "Invalid public key format",
         code: "INVALID_PUBLIC_KEY"
       }, { status: 400 });
     }
+
+    // Normalize public key to uppercase for database query
+    const publicKey = rawPublicKey.toUpperCase();
 
     const neighbors = await getMeshcoreNodeNeighbors(publicKey, lastSeen);
     

--- a/src/app/api/meshcore/node/[publicKey]/route.ts
+++ b/src/app/api/meshcore/node/[publicKey]/route.ts
@@ -6,11 +6,11 @@ export async function GET(
   { params }: { params: Promise<{ publicKey: string }> }
 ) {
   try {
-    const { publicKey } = await params;
+    const { publicKey: rawPublicKey } = await params;
     const { searchParams } = new URL(req.url);
     const limit = parseInt(searchParams.get("limit") || "50", 10);
     
-    if (!publicKey) {
+    if (!rawPublicKey) {
       return NextResponse.json({ 
         error: "Public key is required",
         code: "MISSING_PUBLIC_KEY"
@@ -18,12 +18,15 @@ export async function GET(
     }
 
     // Validate public key format (basic validation)
-    if (publicKey.length < 10) {
+    if (rawPublicKey.length < 10) {
       return NextResponse.json({ 
         error: "Invalid public key format",
         code: "INVALID_PUBLIC_KEY"
       }, { status: 400 });
     }
+
+    // Normalize public key to uppercase for database query
+    const publicKey = rawPublicKey.toUpperCase();
 
     const nodeInfo = await getMeshcoreNodeInfo(publicKey, limit);
     


### PR DESCRIPTION
# Fix: Support Lowercase Public Keys in Node API Endpoints

## Overview
This PR addresses a case sensitivity issue where the node API endpoints required uppercase public keys, but users could only copy lowercase keys from the meshcore app. The API now accepts both lowercase and uppercase public keys by normalizing them to uppercase before database queries.

## Problem
- Users copy node public keys from the meshcore app in lowercase format
- API endpoints `/api/meshcore/node/[publicKey]` and `/api/meshcore/node/[publicKey]/neighbors` only worked with uppercase public keys
- This would result in "Node not found" errors
- The underlying database stores and expects public keys in uppercase format

## Solution
Modified both API endpoints to normalize public keys to uppercase before querying the database:

### Files Changed
1. **`src/app/api/meshcore/node/[publicKey]/route.ts`**
   - Added public key normalization: `const publicKey = rawPublicKey.toUpperCase()`
   - Renamed the parameter to `rawPublicKey` for clarity
   - Maintains all existing validation logic

2. **`src/app/api/meshcore/node/[publicKey]/neighbors/route.ts`**
   - Applied identical normalization logic
   - Ensures consistent behavior across related endpoints

### Technical Details
- **Backward Compatibility**: Existing uppercase URLs continue to work exactly as before
- **New Functionality**: Lowercase public keys are now supported seamlessly
- **Database Consistency**: All queries use uppercase keys as required by the database schema
- **Performance**: Minimal overhead - only adds a single `.toUpperCase()` call per request
- **Validation**: Existing validation logic remains unchanged

## Testing
- ✅ Build verification completed successfully (`npm run build`)
- ✅ TypeScript compilation passes without errors
- ✅ Existing functionality preserved
- ✅ No breaking changes introduced

## API Behavior Examples

### Before
- `GET /api/meshcore/node/ABC123DEF456` ✅ Works
- `GET /api/meshcore/node/abc123def456` ❌ Returns 404

### After
- `GET /api/meshcore/node/ABC123DEF456` ✅ Works (unchanged)
- `GET /api/meshcore/node/abc123def456` ✅ Works (new functionality)
- `GET /api/meshcore/node/AbC123dEf456` ✅ Works (mixed case supported)

## Impact
- **User Experience**: Users can now paste copied public keys directly without manual case conversion
- **API Reliability**: Eliminates case-sensitivity as a source of API failures
- **Consistency**: Both node and neighbors endpoints behave identically