### PR TITLE
chat: fix slow /api/chat query (full-history aggregation)

### DIFF
--- a/meshexplorer/src/lib/clickhouse/actions.ts
+++ b/meshexplorer/src/lib/clickhouse/actions.ts
@@ -2,6 +2,7 @@
 import { clickhouse } from "./clickhouse";
 import { generateRegionWhereClauseFromArray, generateRegionWhereClause, detectRegionFromBrokerTopic, detectRegion } from "@/lib/regionFilters";
 import { getRegionConfig } from "@/lib/regions";
+import { publicChannelMessagesSubquery } from "./chatMessages";
 
 export async function getNodePositions({ minLat, maxLat, minLng, maxLng, nodeTypes, lastSeen }: { minLat?: string | null, maxLat?: string | null, minLng?: string | null, maxLng?: string | null, nodeTypes?: string[], lastSeen?: string | null } = {}) {
   try {
@@ -55,30 +56,40 @@ export async function getNodePositions({ minLat, maxLat, minLng, maxLng, nodeTyp
 
 export async function getLatestChatMessages({ limit = 20, before, after, channelId, region }: { limit?: number, before?: string, after?: string, channelId?: string, region?: string } = {}) {
   try {
-    let where = [];
+    // Filters that can be pushed into the inner meshcore_packets scan so the
+    // ingest_timestamp primary key / partition pruning applies. See
+    // publicChannelMessagesSubquery for why this avoids a full-history scan.
+    const innerWhere: string[] = [];
+    // Filters that must run after aggregation (origin_path_info only exists on
+    // the grouped output).
+    const outerWhere: string[] = [];
     const params: Record<string, any> = { limit };
-    
+
+    // ingest_timestamp must be table-qualified: unqualified, the analyzer binds
+    // it to the `max(ingest_timestamp) AS ingest_timestamp` output alias and
+    // rejects the WHERE (ILLEGAL_AGGREGATION).
     if (before) {
-      where.push('ingest_timestamp < {before:DateTime64}');
+      innerWhere.push('meshcore_packets.ingest_timestamp < {before:DateTime64}');
       params.before = before;
     }
     if (after) {
-      where.push('ingest_timestamp > {after:DateTime64}');
+      innerWhere.push('meshcore_packets.ingest_timestamp > {after:DateTime64}');
       params.after = after;
     }
     if (channelId) {
-      where.push('channel_hash = {channelId:String}');
+      // channel_hash == hex(substring(payload, 1, 1)); push to the raw scan.
+      innerWhere.push('hex(substring(payload, 1, 1)) = {channelId:String}');
       params.channelId = channelId;
     }
-    
-    // Add region filtering if specified
+
+    // Region filtering keys off origin_path_info, which only exists post-group.
     const regionFilter = generateRegionWhereClauseFromArray(region);
     if (regionFilter.whereClause) {
-      where.push(regionFilter.whereClause);
+      outerWhere.push(regionFilter.whereClause);
     }
-    
-    const whereClause = where.length > 0 ? `WHERE ${where.join(' AND ')}` : '';
-    const query = `SELECT ingest_timestamp, mesh_timestamp, channel_hash, mac, hex(encrypted_message) AS encrypted_message, message_count, origin_path_info, message_id FROM meshcore_public_channel_messages ${whereClause} ORDER BY ingest_timestamp DESC LIMIT {limit:UInt32}`;
+
+    const whereClause = outerWhere.length > 0 ? `WHERE ${outerWhere.join(' AND ')}` : '';
+    const query = `SELECT ingest_timestamp, mesh_timestamp, channel_hash, mac, hex(encrypted_message) AS encrypted_message, message_count, origin_path_info, message_id FROM ${publicChannelMessagesSubquery(innerWhere)} ${whereClause} ORDER BY ingest_timestamp DESC LIMIT {limit:UInt32}`;
     const resultSet = await clickhouse.query({ query, query_params: params, format: 'JSONEachRow' });
     const rows = await resultSet.json();
     return rows as Array<{

--- a/meshexplorer/src/lib/clickhouse/chatMessages.ts
+++ b/meshexplorer/src/lib/clickhouse/chatMessages.ts
@@ -1,0 +1,40 @@
+/**
+ * Builds the public-channel-messages aggregation as an inline subquery.
+ *
+ * This mirrors the `meshcore_public_channel_messages` view (group meshcore
+ * packets by payload to dedup the same message seen via multiple gateways), but
+ * lets callers push filters into the inner `meshcore_packets` scan instead of
+ * filtering the fully-aggregated view output.
+ *
+ * Why this matters: in the view, `ingest_timestamp` is `max(ingest_timestamp)`
+ * and `channel_hash` is derived from the grouped `payload`. A WHERE on those
+ * columns can't be pushed below the GROUP BY, so ClickHouse must aggregate the
+ * entire payload_type=5 history (millions of rows) on every query before the
+ * filter applies — the timestamp primary key never gets used. Pushing the time
+ * and channel filters into `innerConditions` lets partition + primary-key
+ * pruning (ORDER BY starts with ingest_timestamp) kick in, turning a ~1 GiB
+ * full scan into a few-millisecond ranged read.
+ *
+ * @param innerConditions Extra predicates applied to the meshcore_packets scan,
+ *   before grouping. `payload_type = 5` is always included. Reference
+ *   `ingest_timestamp` as `meshcore_packets.ingest_timestamp` — unqualified it
+ *   binds to the `max(ingest_timestamp)` output alias and the query is rejected
+ *   with ILLEGAL_AGGREGATION.
+ */
+export function publicChannelMessagesSubquery(innerConditions: string[] = []): string {
+  const where = ["payload_type = 5", ...innerConditions].join(" AND ");
+  return `(
+    SELECT
+      max(ingest_timestamp) AS ingest_timestamp,
+      min(mesh_timestamp) AS mesh_timestamp,
+      hex(substring(payload, 1, 1)) AS channel_hash,
+      hex(substring(payload, 2, 2)) AS mac,
+      substring(payload, 4) AS encrypted_message,
+      count() AS message_count,
+      groupArray((origin, hex(origin_pubkey), hex(path), broker, topic)) AS origin_path_info,
+      any(packet_hash) AS message_id
+    FROM meshcore_packets
+    WHERE ${where}
+    GROUP BY payload
+  )`;
+}

--- a/meshexplorer/src/lib/clickhouse/streaming.ts
+++ b/meshexplorer/src/lib/clickhouse/streaming.ts
@@ -1,5 +1,6 @@
 import { clickhouse } from './clickhouse';
 import { generateRegionConditionForStreaming, generateRegionArrayConditionForStreaming } from '../regionFilters';
+import { publicChannelMessagesSubquery } from './chatMessages';
 
 /**
  * Configuration for the ClickHouse streaming poller
@@ -257,9 +258,14 @@ export function createChatMessagesStreamerConfig(
     }
   }
 
+  // Push the poll cursor into the inner meshcore_packets scan so partition /
+  // primary-key pruning limits it to the last few seconds of packets, instead
+  // of re-aggregating the entire payload_type=5 history every 250ms. The outer
+  // WHERE keeps the same predicate so the streamer can still splice in
+  // channel_hash / region filters (origin_path_info only exists post-group).
   return {
     queryTemplate: `
-      SELECT 
+      SELECT
         ingest_timestamp,
         mesh_timestamp,
         channel_hash,
@@ -268,7 +274,7 @@ export function createChatMessagesStreamerConfig(
         message_count,
         origin_path_info,
         message_id
-      FROM meshcore_public_channel_messages 
+      FROM ${publicChannelMessagesSubquery(['meshcore_packets.ingest_timestamp > {lastTimestamp:DateTime64}'])}
       WHERE ingest_timestamp > {lastTimestamp:DateTime64}
       ORDER BY ingest_timestamp DESC
       LIMIT {maxRows:UInt32}


### PR DESCRIPTION
## Problem

`/api/chat` (e.g. `?region=seattle&channel_id=11&after=...`) took ~0.4–0.8s regardless of the `after` filter. The endpoint queries the `meshcore_public_channel_messages` **VIEW**, which does `GROUP BY payload` over all `payload_type=5` packets. Filtering its *output* on `ingest_timestamp`/`channel_hash` can't push below the `GROUP BY` — `ingest_timestamp` is `max(ingest_timestamp)` and `channel_hash` derives from the grouped `payload`. So every call re-aggregated the **entire history** and the `ingest_timestamp` primary key was never used.

Measured on prod ClickHouse: **8,064,097 rows / 1.21 GiB / ~300 MB RAM** read every call, no matter the time window.

## Fix

Replace the view reference with an inline subquery (`publicChannelMessagesSubquery`) that pushes the time/channel filters into the inner `meshcore_packets` scan, so partition + primary-key pruning (`ORDER BY (ingest_timestamp, …)`) applies and only the small filtered window is grouped. Region filtering stays on the outer query since `origin_path_info` only exists post-aggregation. Same change applied to the chat streaming poller.

Gotcha handled: `ingest_timestamp` is table-qualified in the inner WHERE — unqualified it binds to the `max(ingest_timestamp)` output alias and throws `ILLEGAL_AGGREGATION`.

## Verification (prod ClickHouse)

- **Output identical** — `diff` of `(message_id, message_count)` between old view query and rewrite (channel 11, seattle, same window) → identical.

| | rows read | bytes | mem | time |
|---|---|---|---|---|
| old (view) | 8,064,097 | 1.21 GiB | ~300 MB | ~400–760 ms |
| new (pushdown) | 114,284 | 16.75 MiB | 8.75 MB | **28 ms** |

Still on the view (different time-bucketed access pattern, out of scope): `api/stats/popular-channels` and the Grafana dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)