### PR TITLE
Fix "show all neighbors" rendering edges only in the PNW

### DIFF
--- a/meshexplorer/src/lib/clickhouse/actions.ts
+++ b/meshexplorer/src/lib/clickhouse/actions.ts
@@ -309,17 +309,18 @@ export async function getAllNodeNeighbors(lastSeen: string | null = null, minLat
     // by region + bounding box + lastSeen. The heavy graph computation lives in the
     // refreshable materialized view meshcore_all_neighbor_edges.
     // Region filter for the precomputed neighbor graph: a region selector -> that region; a group
-    // selector -> its member regions (resolved in-DB against region_groups); else default to SEA.
-    // The MV only holds intra-region edges, so a group never produces cross-region neighbors.
+    // selector -> its member regions (resolved in-DB against region_groups); no selector -> all
+    // regions (no filter). The MV only holds intra-region edges, so neither a group nor the
+    // all-regions case ever produces cross-region neighbors.
     const params: Record<string, any> = {};
     const nbrCode = normalizeRegion(region);
     const nbrGroup = groupCodeOf(region);
-    let nbrRegionFilter: string;
+    let nbrRegionFilter: string | null;
     if (nbrCode) { nbrRegionFilter = "region = {region:String}"; params.region = nbrCode; }
     else if (nbrGroup) { nbrRegionFilter = "region IN (SELECT region_code FROM region_groups WHERE group_code = {grp:String})"; params.grp = nbrGroup; }
-    else { nbrRegionFilter = "region = {region:String}"; params.region = "SEA"; }
+    else { nbrRegionFilter = null; } // no selector -> all regions
     const whereConditions = [
-      nbrRegionFilter,
+      ...(nbrRegionFilter ? [nbrRegionFilter] : []),
       "source_has_location = 1",
       "target_has_location = 1",
       "source_latitude IS NOT NULL",


### PR DESCRIPTION
## Problem

With "Show all neighbors" enabled and no region selected, the map renders node dots for all regions but neighbor edges (connection lines) only ever appear around the Pacific Northwest — Vancouver, Seattle, Portland — no matter where you pan.

## Root cause

`getAllNodeNeighbors()` hard-defaulted to `region = 'SEA'` when no region was selected. `SEA` is the catch-all for the bare `meshcore` / `meshcore/salish` topics, which span the whole PNW geographically. So the edge query silently returned only PNW edges, while `getNodePositions()` (which has no region filter) returned dots everywhere — producing the mismatch.

## Fix

When the selector resolves to neither a region nor a group, apply no region filter at all, so edges show for every region. Results are still bounded by the viewport bounding box, `lastSeen`, and node-type filters. The neighbor-edge materialized view holds intra-region edges only, so this never produces cross-region lines.

Single-file change in `getAllNodeNeighbors()`; both callers (`/api/map?includeNeighbors=true` and `/api/neighbors/all`) forward region through this one function, so no other changes were needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)