### PR TITLE
Refetch map neighbors when the selected region changes

### DIFF
--- a/meshexplorer/src/components/MapView.tsx
+++ b/meshexplorer/src/components/MapView.tsx
@@ -696,7 +696,7 @@ export default function MapView({ target = '_self' }: MapViewProps = {}) {
           setAllNeighborsLoading(false);
         }
       });
-  }, [mapLayerSettings.nodeTypes, config?.lastSeen]);
+  }, [mapLayerSettings.nodeTypes, config?.lastSeen, config?.selectedRegion]);
 
   function isBoundsInside(inner: [[number, number], [number, number]], outer: [[number, number], [number, number]]) {
     // inner: [[minLat, minLng], [maxLat, maxLng]]


### PR DESCRIPTION
## Problem

Changing the selected region in the frontend did not trigger a new neighbors fetch — the neighbor lines stayed scoped to the *previous* region until a full page refresh.

## Root cause

`fetchNodes()` in `MapView.tsx` reads `config.selectedRegion` when building the `/api/map` request, but its `useCallback` dependency array only listed `[mapLayerSettings.nodeTypes, config?.lastSeen]`. When only the region changed, `fetchNodes` was not recreated, so the effect that drives fetching invoked a stale closure that still carried the old region.

## Fix

Add `config?.selectedRegion` to the `fetchNodes` `useCallback` dependency array so the closure (and the resulting fetch) picks up the new region immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)