### PR TITLE
Add grayscale map toggle (#29)

### DIFF
--- a/meshexplorer/src/app/globals.css
+++ b/meshexplorer/src/app/globals.css
@@ -266,3 +266,8 @@ html {
 .slider::-moz-range-thumb:hover {
   background: #1d4ed8;
 }
+
+/* Desaturate only the base map tiles so colored route lines/markers stand out */
+.grayscale-tiles .leaflet-tile-pane {
+  filter: grayscale(1);
+}

--- a/meshexplorer/src/components/MapLayerSettings.tsx
+++ b/meshexplorer/src/components/MapLayerSettings.tsx
@@ -256,7 +256,18 @@ export default function MapLayerSettingsComponent({ onSettingsChange }: MapLayer
             </select>
           </div>
 
-          {/* Show meshcore coverage overlay 
+          {/* Grayscale map */}
+          <label className="flex items-center gap-2 mb-3 cursor-pointer">
+            <input
+              type="checkbox"
+              checked={settings.grayscaleTiles}
+              onChange={(e) => updateSetting('grayscaleTiles', e.target.checked)}
+              className="rounded"
+            />
+            <span className="text-sm text-gray-700 dark:text-gray-300">Grayscale map</span>
+          </label>
+
+          {/* Show meshcore coverage overlay
           <label className="flex items-center gap-2 mb-3 cursor-pointer">
             <input
               type="checkbox"

--- a/meshexplorer/src/components/MapView.tsx
+++ b/meshexplorer/src/components/MapView.tsx
@@ -549,6 +549,7 @@ export default function MapView({ target = '_self' }: MapViewProps = {}) {
     showNodeNames: true,
     enableClustering: true,
     tileLayer: "openstreetmap",
+    grayscaleTiles: false,
     showAllNeighbors: false,
     useColors: true,
     onlyMqttNeighbors: false,
@@ -849,7 +850,7 @@ export default function MapView({ target = '_self' }: MapViewProps = {}) {
         center={mapCenter}
         zoom={mapZoom}
         style={{ width: "100%", height: "100%", zIndex: 1 }}
-        className="bg-gray-200"
+        className={`bg-gray-200${mapLayerSettings.grayscaleTiles ? ' grayscale-tiles' : ''}`}
       >
         <InitialBoundsSetter />
         <MapEventCatcher />

--- a/meshexplorer/src/hooks/useMapLayerSettings.ts
+++ b/meshexplorer/src/hooks/useMapLayerSettings.ts
@@ -8,6 +8,7 @@ export interface MapLayerSettings {
   showNodeNames: boolean;
   enableClustering: boolean;
   tileLayer: string;
+  grayscaleTiles: boolean;
   showAllNeighbors: boolean;
   useColors: boolean;
   onlyMqttNeighbors: boolean;
@@ -22,6 +23,7 @@ const DEFAULT_MAP_LAYER_SETTINGS: MapLayerSettings = {
   showNodeNames: true,
   enableClustering: true,
   tileLayer: "openstreetmap",
+  grayscaleTiles: false,
   showAllNeighbors: false,
   useColors: true,
   onlyMqttNeighbors: false,


### PR DESCRIPTION
## Summary
Addresses part 1 of #29 — adds an option to gray out the background map so colored route lines and node markers stand out. (Adjustable line thickness already existed.)

- New **"Grayscale map"** checkbox in the map settings popover, under the Tile layer dropdown
- Persists in `mapLayerSettings` (localStorage), following the existing settings pattern
- CSS `grayscale` filter scoped to Leaflet's tile pane only, so markers/route lines stay in full color and it works with any selected tileset (OSM / OpenTopoMap / Esri) without relying on third-party grayscale tile servers

## Files
- `useMapLayerSettings.ts` — add `grayscaleTiles` to interface + defaults
- `MapLayerSettings.tsx` — checkbox control
- `MapView.tsx` — conditional `grayscale-tiles` class on `MapContainer`
- `globals.css` — `.grayscale-tiles .leaflet-tile-pane { filter: grayscale(1); }`

## Out of scope
Issue part 2 (encoding SNR / packet-count into line width/color) deferred to a follow-up.

## Verification
`tsc --noEmit` passes; `npm run lint` clean (only a pre-existing unrelated warning). Toggle in the layers popover desaturates the base map while overlays remain colored; setting persists across reload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)